### PR TITLE
Fix ENOTDIR for tarballs w/o nested 'package' dir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ import {join as joinPath} from 'path';
 import downloadTarball from 'download-tarball';
 import rimraf from 'rimraf-then';
 import mkdirp from 'mkdirp-then';
-import {readdir, move} from 'fs-extra';
+import {readdir, move, existsSync} from 'fs-extra';
 import tmp from 'then-tmp';
 import npa from 'npm-package-arg';
 import readJSON from 'then-read-json';
@@ -15,7 +15,10 @@ const makeParentDir = (dir, scope) => {
 module.exports = async ({url, gotOpts, dir}) => {
   const {path: tmpPath, cleanupCallback} = await tmp.dir();
   await downloadTarball({url, gotOpts, dir: tmpPath});
-  const [fromDirname] = await readdir(tmpPath);
+  const tarballContents = await readdir(tmpPath);
+  const fromDirname = tarballContents.includes('package.json')
+    ? '.'
+    : tarballContents[0]  /* package subfolder */;
   const src = joinPath(tmpPath, fromDirname);
   const {name} = await readJSON(joinPath(src, 'package.json'));
   const {scope} = npa(name);
@@ -25,5 +28,7 @@ module.exports = async ({url, gotOpts, dir}) => {
   await rimraf(dest);
   await move(src, dest);
 
-  cleanupCallback();
+  if (existsSync(tmpPath)) {
+    cleanupCallback();
+  }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,9 +16,8 @@ module.exports = async ({url, gotOpts, dir}) => {
   const {path: tmpPath, cleanupCallback} = await tmp.dir();
   await downloadTarball({url, gotOpts, dir: tmpPath});
   const tarballContents = await readdir(tmpPath);
-  const fromDirname = tarballContents.includes('package.json')
-    ? '.'
-    : tarballContents[0]  /* package subfolder */;
+  const isSubfolder = !tarballContents.includes('package.json');
+  const fromDirname = isSubfolder ? tarballContents[0] : '.';
   const src = joinPath(tmpPath, fromDirname);
   const {name} = await readJSON(joinPath(src, 'package.json'));
   const {scope} = npa(name);


### PR DESCRIPTION
For an example, see:
https://registry.npmjs.org/webgl-workshop/-/webgl-workshop-1.2.1.tgz
Closes #11.